### PR TITLE
Fix typo in event dp--cookie-content

### DIFF
--- a/src/js/dp_cookieconsent.js
+++ b/src/js/dp_cookieconsent.js
@@ -842,12 +842,12 @@ import defaultL10n from './l10n/en';
                     if (src && src.length > 0) {
                         this.ajax('GET', src, function (response) {
                             element.innerHTML = response.response;
-                            cc.utils.fireEvent('dp--cookie-conent', element);
+                            cc.utils.fireEvent('dp--cookie-content', element);
                         }, function (error) {
                         });
                     } else {
                         /** call Inline Event **/
-                        cc.utils.fireEvent('dp--cookie-conent', element);
+                        cc.utils.fireEvent('dp--cookie-content', element);
                     }
                 })
             }


### PR DESCRIPTION
Fix the typo as issued here:

 https://github.com/DirkPersky/typo3-dp_cookieconsent/issues/97